### PR TITLE
Fixing the Transcendence bug once and for all

### DIFF
--- a/Items/ElectroPlankton.cs
+++ b/Items/ElectroPlankton.cs
@@ -220,14 +220,7 @@ namespace SupplyDrop.Items
             var inventoryCount = GetCount(sender);
             if (inventoryCount > 0)
             {
-                if (sender.inventory.GetItemCount(ItemIndex.ShieldOnly) > 0)
-                {
-                    args.baseShieldAdd += ((sender.levelMaxHealth * baseStackHPPercent));
-                }
-                else
-                {
-                    args.baseShieldAdd += ((sender.maxHealth * baseStackHPPercent));
-                }
+                ItemHelpers.AddMaxShieldHelper(sender, args, inventoryCount, baseStackHPPercent, 0);
             }
         }
         private void ShieldOnHit(On.RoR2.HealthComponent.orig_TakeDamage orig, HealthComponent self, DamageInfo damageInfo)

--- a/Items/QSGen.cs
+++ b/Items/QSGen.cs
@@ -227,14 +227,7 @@ namespace SupplyDrop.Items
             var inventoryCount = GetCount(sender);
             if (inventoryCount > 0)
             {
-                if (sender.inventory.GetItemCount(ItemIndex.ShieldOnly) > 0)
-                {
-                    args.baseShieldAdd += ((sender.levelMaxHealth * baseStackHPPercent));
-                }
-                else
-                {
-                    args.baseShieldAdd += ((sender.maxHealth * baseStackHPPercent));
-                }
+                ItemHelpers.AddMaxShieldHelper(sender, args, inventoryCount, baseStackHPPercent, 0);
             }
         }
         private void CalculateDamageReduction(On.RoR2.HealthComponent.orig_TakeDamage orig, HealthComponent self, DamageInfo damageInfo)

--- a/Items/SalvagedWires.cs
+++ b/Items/SalvagedWires.cs
@@ -217,14 +217,7 @@ namespace SupplyDrop.Items
             var inventoryCount = GetCount(sender);
             if (inventoryCount > 0)
             {
-                if (sender.inventory.GetItemCount(ItemIndex.ShieldOnly) > 0)
-                {
-                    args.baseShieldAdd += ((sender.levelMaxHealth * baseStackHPPercent) + ((sender.levelMaxHealth * addStackHPPercent) * (inventoryCount - 1)));
-                }
-                else
-                {
-                    args.baseShieldAdd += ((sender.maxHealth * baseStackHPPercent) + ((sender.maxHealth * addStackHPPercent) * (inventoryCount - 1)));
-                }
+                ItemHelpers.AddMaxShieldHelper(sender, args, inventoryCount, baseStackHPPercent, addStackHPPercent);
             }
         }
         private void AttackSpeedBonus(CharacterBody sender, StatHookEventArgs args)

--- a/Items/UnassumingTie.cs
+++ b/Items/UnassumingTie.cs
@@ -261,14 +261,7 @@ namespace SupplyDrop.Items
             var inventoryCount = GetCount(sender);
             if (inventoryCount > 0)
             {
-                if (sender.inventory.GetItemCount(ItemIndex.ShieldOnly) > 0)
-                {
-                    args.baseShieldAdd += ((sender.levelMaxHealth * baseStackHPPercent) + ((sender.levelMaxHealth * addStackHPPercent) * (inventoryCount - 1)));
-                }
-                else
-                {
-                    args.baseShieldAdd += ((sender.maxHealth * baseStackHPPercent) + ((sender.maxHealth * addStackHPPercent) * (inventoryCount - 1)));
-                }
+                ItemHelpers.AddMaxShieldHelper(sender, args, inventoryCount, baseStackHPPercent, addStackHPPercent);
             }
         }
         private void AddWindedDebuff(On.RoR2.CharacterBody.orig_RemoveBuff orig, CharacterBody self, BuffIndex buffType)

--- a/Utilities/ItemHelpers.cs
+++ b/Utilities/ItemHelpers.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using static TILER2.StatHooks;
 
 namespace SupplyDrop.Utils
 {
@@ -28,5 +29,45 @@ namespace SupplyDrop.Utils
 
         }
 
+        public static void AddMaxShieldHelper(CharacterBody sender, StatHookEventArgs args, int inventoryCount, float baseStackHPPercent, float addStackHPPercent)
+        {
+            //if (inventoryCount > 0) //Keroro's preferred behavior.
+            //{
+            //    if (sender.inventory.GetItemCount(ItemIndex.ShieldOnly) > 0)
+            //    {
+            //        args.baseShieldAdd += ((sender.maxShield * baseStackHPPercent) + ((sender.maxShield * addStackHPPercent * (inventoryCount - 1)));
+            //    }
+            //    else
+            //    {
+            //        args.baseShieldAdd += ((sender.maxHealth * baseStackHPPercent) + ((sender.maxHealth * addStackHPPercent) * (inventoryCount - 1)));
+            //    };
+            //}
+
+
+            if (inventoryCount > 0) //Personal Shield Generator behavior.
+            {
+                if (sender.inventory.GetItemCount(ItemIndex.ShieldOnly) > 0) //Retained the if-else statement to increase compatibility with mods that add HP in unexpected ways when the player does not have Transcendence.
+                {
+                    //Max health before Transcendence transformation is not stored in any way. It must be recalculated manually. The following code was adapted from CharacterBody.RecalculateStats().
+
+                    float calcHealthMultiplier = 1f //Base multiplier
+                        + (float)sender.inventory.GetItemCount(ItemIndex.BoostHp) * 0.1f //BoostHp
+                        + (float)(sender.inventory.GetItemCount(ItemIndex.Pearl) + sender.inventory.GetItemCount(ItemIndex.ShinyPearl)) * 0.1f; //Pearls;
+
+
+                    float calcMaxHealth = ((sender.baseMaxHealth + sender.levelMaxHealth * (sender.level - 1)) //Base max HP
+                        + (float)sender.inventory.GetItemCount(ItemIndex.Knurl) * 40f //Knurls
+                        + (sender.inventory.GetItemCount(ItemIndex.Infusion) > 0 ? sender.inventory.infusionBonus : 0)) //Infusion
+                        * calcHealthMultiplier //Health multiplier - pearls and BoostHp
+                        / ((float)sender.inventory.GetItemCount(ItemIndex.CutHp) + 1) //Shaped Glass
+                        * (sender.inventory.GetItemCount(ItemIndex.InvadingDoppelganger) > 0 ? 10 : 1); //Check if you're a doppelganger.
+                    args.baseShieldAdd += (calcMaxHealth * baseStackHPPercent) + (calcMaxHealth * addStackHPPercent) * (inventoryCount - 1);
+                }
+                else
+                {
+                    args.baseShieldAdd += ((sender.maxHealth * baseStackHPPercent) + ((sender.maxHealth * addStackHPPercent) * (inventoryCount - 1)));
+                };
+            }
+        }
     }
 }

--- a/Utilities/ItemHelpers.cs
+++ b/Utilities/ItemHelpers.cs
@@ -35,7 +35,7 @@ namespace SupplyDrop.Utils
             //{
             //    if (sender.inventory.GetItemCount(ItemIndex.ShieldOnly) > 0)
             //    {
-            //        args.baseShieldAdd += ((sender.maxShield * baseStackHPPercent) + ((sender.maxShield * addStackHPPercent * (inventoryCount - 1)));
+            //        args.baseShieldAdd += ((sender.maxShield * baseStackHPPercent) + ((sender.maxShield * addStackHPPercent * (inventoryCount - 1))));
             //    }
             //    else
             //    {


### PR DESCRIPTION
I noticed that the Transcendence bug with shield items was still happening, so I investigated it myself.

It turns out that pre-Transcendence max health isn't stored anywhere, so it must be recalculated manually.

I have added an AddMaxShieldHelper method to ItemHelpers.cs with two implementations - one acts like Personal Shield Generator (adds shields based on previous max health) and one does the behavior mentioned in the Supply Drop 1.4.2 patch notes (increase shields based on total shields post-Transcendence). The total shield implementation is commented out- to switch to it, you just need to comment out or delete the PSG implementation and uncomment the total shield implementation.

I tested both implementations and they are working properly. The PSG behavior may have a small compatibility issue with mods that add items that increase max health in unexpected ways. In that case, when a player has Transcendence and picks up one of your items, they will receive slightly less shields than they should. Not a big deal.