### PR TITLE
update action tasks and dotnet SDK

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -12,20 +12,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.2.1
+      uses: actions/upload-artifact@v3
       with:
         # Artifact name
         name: SupplyDrop.dll
         # A file, directory or wildcard pattern that describes what to upload
         path: bin/Release/netstandard2.0/SupplyDrop.dll
         # The desired behavior if no files are found using the provided path.
+        if-no-files-found: error


### PR DESCRIPTION
This will get rid of some of the warnings in the action build, plus error out if the DLL doesn't actually get built for some reason.